### PR TITLE
Expose BrowserDriver and clean up HomeNav

### DIFF
--- a/TheInternetSpecFlow/Drivers/BrowserDriver.cs
+++ b/TheInternetSpecFlow/Drivers/BrowserDriver.cs
@@ -5,12 +5,12 @@ namespace TheInternetSpecFlow.Drivers
 {
     public class BrowserDriver : IDisposable
     {
-        private readonly IWebDriver _webDriver;
+        public readonly IWebDriver webDriver;
         private bool _isDisposed;
 
         public BrowserDriver()
         {
-            _webDriver = CreateWebDriver();
+            webDriver = CreateWebDriver();
         }
 
         private IWebDriver CreateWebDriver()
@@ -29,28 +29,8 @@ namespace TheInternetSpecFlow.Drivers
                 return;
             }
 
-            _webDriver.Quit();
+            webDriver.Quit();
             _isDisposed = true;
-        }
-
-        public string GetTitle()
-        {
-            return _webDriver.Title;
-        }
-
-        public void NavigateToURL(string URL)
-        {
-            _webDriver.Navigate().GoToUrl(URL);
-        }
-
-        public string GetURL()
-        {
-            return _webDriver.Url;
-        }
-
-        public List<IWebElement> FindElementsByCSSSelector(string selector)
-        {
-            return _webDriver.FindElements(By.CssSelector(selector)).ToList();
         }
     }
 }

--- a/TheInternetSpecFlow/Pages/HomeNavPage.cs
+++ b/TheInternetSpecFlow/Pages/HomeNavPage.cs
@@ -6,7 +6,6 @@ namespace TheInternetSpecFlow.Pages
     {
         private readonly BrowserDriver _browser;
         private readonly HttpClient _client;
-        private static List<IWebElement> _linksOnPage = new List<IWebElement>();
 
         public HomeNavPage(BrowserDriver browser)
         {
@@ -15,35 +14,25 @@ namespace TheInternetSpecFlow.Pages
         }
         public void GoToHomePage()
         {
-            _browser.NavigateToURL("http://127.0.0.1:7080/");
-            Assert.True(
-                _browser
-                .GetTitle()
-                .Equals("The Internet")
-            );
-        }
-
-        public void GetLinksOnHomePage()
-        {
-            if (_linksOnPage.Count == 0)
-            {
-                _linksOnPage = _browser.FindElementsByCSSSelector("ul a");
-            }
+            _browser.webDriver.Navigate().GoToUrl("http://127.0.0.1:7080/");
+            Assert.True(_browser.webDriver.Title.Equals("The Internet"));
         }
 
         public int GetNumberOfLinksOnHomePage()
         {
+            var _linksOnPage = _browser.webDriver.FindElements(By.CssSelector("ul a"));
             return _linksOnPage.Count;
         }
 
         public void HrefExistsOnHomePage(string page)
         {
-            Assert.Contains(_linksOnPage, a => a.GetAttribute("href") == _browser.GetURL() + page);
+            var _linksOnPage = _browser.webDriver.FindElements(By.CssSelector("ul a"));
+            Assert.Contains(_linksOnPage, a => a.GetAttribute("href") == _browser.webDriver.Url + page);
         }
 
         public int SendRequestToHref(string page)
         {
-            HttpResponseMessage response = _client.GetAsync(_browser.GetURL() + page).Result;
+            HttpResponseMessage response = _client.GetAsync(_browser.webDriver.Url + page).Result;
             return (int)response.StatusCode;
         }
     }

--- a/TheInternetSpecFlow/Pages/HomeNavPage.cs
+++ b/TheInternetSpecFlow/Pages/HomeNavPage.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium;
+using System.Security.Policy;
 
 namespace TheInternetSpecFlow.Pages
 {
@@ -6,7 +7,6 @@ namespace TheInternetSpecFlow.Pages
     {
         private readonly BrowserDriver _browser;
         private readonly HttpClient _client;
-        private static List<IWebElement> _linksOnPage = new List<IWebElement>();
 
         public HomeNavPage(BrowserDriver browser)
         {
@@ -15,35 +15,25 @@ namespace TheInternetSpecFlow.Pages
         }
         public void GoToHomePage()
         {
-            _browser.NavigateToURL("http://127.0.0.1:7080/");
-            Assert.True(
-                _browser
-                .GetTitle()
-                .Equals("The Internet")
-            );
-        }
-
-        public void GetLinksOnHomePage()
-        {
-            if (_linksOnPage.Count == 0)
-            {
-                _linksOnPage = _browser.FindElementsByCSSSelector("ul a");
-            }
+            _browser.webDriver.Navigate().GoToUrl("http://127.0.0.1:7080/");
+            Assert.True(_browser.webDriver.Title.Equals("The Internet"));
         }
 
         public int GetNumberOfLinksOnHomePage()
         {
+            var _linksOnPage = _browser.webDriver.FindElements(By.CssSelector("ul a"));
             return _linksOnPage.Count;
         }
 
         public void HrefExistsOnHomePage(string page)
         {
-            Assert.Contains(_linksOnPage, a => a.GetAttribute("href") == _browser.GetURL() + page);
+            var _linksOnPage = _browser.webDriver.FindElements(By.CssSelector("ul a"));
+            Assert.Contains(_linksOnPage, a => a.GetAttribute("href") == _browser.webDriver.Url + page);
         }
 
         public int SendRequestToHref(string page)
         {
-            HttpResponseMessage response = _client.GetAsync(_browser.GetURL() + page).Result;
+            HttpResponseMessage response = _client.GetAsync(_browser.webDriver.Url + page).Result;
             return (int)response.StatusCode;
         }
     }

--- a/TheInternetSpecFlow/StepDefinitions/HomeNavStepDefinitions.cs
+++ b/TheInternetSpecFlow/StepDefinitions/HomeNavStepDefinitions.cs
@@ -4,6 +4,7 @@
     public class HomeNavStepDefinitions
     {
         private int _statusCode;
+        private int _numLinks;
         private readonly HomeNavPage _homeNav;
 
         public HomeNavStepDefinitions(BrowserDriver browserDriver)
@@ -15,14 +16,14 @@
         [Given("the links on the main section of the home page")]
         public void GivenTheLinksOnTheMainSectionOfTheHomePage()
         {
-            _homeNav.GetLinksOnHomePage();
+            _numLinks = _homeNav.GetNumberOfLinksOnHomePage();
         }
 
         // Test 1
         [Then("the count of the number of links on the home page should be (.*)")]
         public void TheCountOfTheNumberOfLinksShouldBe(int numLinks)
         {
-            _homeNav.GetNumberOfLinksOnHomePage().Should().Be(numLinks);
+            _numLinks.Should().Be(numLinks);
         }
 
         // Test 2


### PR DESCRIPTION
There's no point in having the BrowserDriver private. Your code should use the commonly used Selenium methods, not your own prettied up wrappings that do the exact same thing.